### PR TITLE
Fix Slowloris attack vulnerability in HTTP server

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -354,8 +354,12 @@ func (s *Server) Start() error {
 
 	// Create http.Server for graceful shutdown support
 	s.httpServer = &http.Server{
-		Addr:    addr,
-		Handler: s.router,
+		Addr:              addr,
+		Handler:           s.router,
+		ReadHeaderTimeout: 10 * time.Second, // Prevent Slowloris attacks (G112)
+		ReadTimeout:       30 * time.Second, // Maximum time to read entire request
+		WriteTimeout:      30 * time.Second, // Maximum time to write response
+		IdleTimeout:       60 * time.Second, // Maximum time to wait for next request (keep-alive)
 	}
 
 	return s.httpServer.ListenAndServe()


### PR DESCRIPTION
Add timeout configurations to http.Server to prevent Slowloris attacks:
- ReadHeaderTimeout: 10s - Prevents slow header attacks
- ReadTimeout: 30s - Limits request read time
- WriteTimeout: 30s - Limits response write time
- IdleTimeout: 60s - Limits keep-alive idle time

Fixes gosec G112 (CWE-400): Potential Slowloris Attack