### PR TITLE
Unknown task - clarification needed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24.2'
+          go-version: '1.24.10'
 
       - name: Install dependencies
         run: go mod download


### PR DESCRIPTION
Updates Go from 1.24.2 to 1.24.10 to address 7 standard library vulnerabilities:
- GO-2025-4013: Certificate validation with DSA keys
- GO-2025-4011: DER parsing memory exhaustion
- GO-2025-4010: IPv6 hostname validation
- GO-2025-4009: PEM parsing complexity
- GO-2025-4008: TLS ALPN error info leak
- GO-2025-4007: X509 name constraints
- GO-2025-4006: Email parsing CPU consumption

All vulnerabilities are fixed in Go 1.24.8-1.24.10.